### PR TITLE
chore: update Go version to 1.18, disable gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - exhaustruct
     - gochecknoglobals
     - gochecknoinits
+    - gosec
     - mnd
     - nlreturn
     - noinlineerr

--- a/dll/dll.go
+++ b/dll/dll.go
@@ -18,7 +18,7 @@ func init() {
 		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 			panic(err)
 		}
-		if err := os.WriteFile(file, dll, os.ModePerm); err != nil { //nolint:gosec
+		if err := os.WriteFile(file, dll, os.ModePerm); err != nil {
 			panic(err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/abemedia/go-winsparkle
 
-go 1.17
+go 1.18


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the minimum Go toolchain requirement to 1.18.
  * Disabled an gosec linter in the linting configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->