### PR TITLE
ci(test): run tests on all supported architectures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,18 @@ on:
 
 jobs:
   test:
-    name: Test
-    runs-on: windows-latest
+    name: Test (${{ matrix.goarch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: windows-latest
+            goarch: amd64
+          - runner: windows-latest
+            goarch: '386'
+          - runner: windows-11-arm
+            goarch: arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -20,9 +30,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Run linter
+        if: matrix.goarch == 'amd64'
         uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
       - name: Run tests
         run: go test -v -coverpkg=./... ./...
+        env:
+          GOARCH: ${{ matrix.goarch }}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/abemedia/go-winsparkle
 
-go 1.18
+go 1.20


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated testing across Windows AMD64, 386, and ARM64 environments.
  * Continued linting on the primary architecture while running tests for each supported architecture.

* **Chores**
  * Updated the required Go version to 1.20.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->